### PR TITLE
Fix typos and grammar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Boost::ASIO low-level redis client (connector)
 ## Features
 
 - header only
-- low-level controls (i.e. you can cancel, or do you manual DNS-resolving before connection)
+- low-level controls (i.e. you can cancel, or do manual DNS-resolving before a connection)
 - unix domain sockets support
 - works on linux (clang, gcc) and windows (msvc)
 - synchronous & asynchronous interface
@@ -56,18 +56,18 @@ Results achieved with `examples/speed_test_async_multi.cpp` for 1 thread, Intel 
 |----------------------------|------------------------------|
 |  1.30257e+06               |  1.19214e+06                 |
 
-Results are not completely fair, because of usage of different semantics in
-APIs; however they are still interesting, as there are used different
-underlying event libraries ([Boost::ASIO](http://www.boost.org/doc/libs/release/libs/asio/) vs [libev](http://software.schmorp.de/pkg/libev.html)) as well redis protocol
-parsing library (written from scratch vs [hiredis](https://github.com/redis/hiredis))
+These results are not completely fair, because of the usage of different semantics in the
+APIs; however they are still interesting, as they are using different
+underlying event libraries ([Boost::ASIO](http://www.boost.org/doc/libs/release/libs/asio/) vs [libev](http://software.schmorp.de/pkg/libev.html)) as well as redis protocol
+parsing libraries (written from scratch vs [hiredis](https://github.com/redis/hiredis))
 
 ## Work with the result
 
-The general idea is that the result of attempt to  redis reply can be either: no enough data or protocol error (exteame case) or some positive parse result. The last one is just **markers** of result, which is actually stored in *receive buffer* (i.e. outside of markers, and outside of bredis-connection).
+The general idea is that the result of trying to parse a redis reply can be either: not enough data, protocol error (in an extreme case) or some positive parse result. The last one is just **markers** of the result, which is actually stored in the *receive buffer* (i.e. outside of markers, and outside of the bredis-connection).
 
-The the further work with markers denends on your needs: it is possible either **scan** the result for the expected results (e.g. for `PONG` reply on `PING` command, or for `OK`/`QUEUED` replies on `MULTI`/`EXEC` commands) or **extract** the results (the common redis types: `nil`, `string`, `error`, `int` or (recursive) array of them).
+The the further work with markers depends on your needs: it is possible to either **scan** the result for the expected results (e.g. for a `PONG` reply on a `PING` command, or for `OK`/`QUEUED` replies on `MULTI`/`EXEC` commands) or to **extract** the results (the common redis types: `nil`, `string`, `error`, `int` or a (recursive) array of them).
 
-When data in receive buffer is no logner required, it should be consumed.
+When the data in the receive buffer is no longer required, it should be consumed.
 
 Scan example:
 
@@ -80,15 +80,15 @@ using Buffer = boost::asio::streambuf;
 ...
 Buffer rx_buff;
 auto result_markers = c.read(rx_buff);
-/* check for the responce */
+/* check for the response */
 auto eq_pong = r::marker_helpers::equality<Iterator>("PONG");
 /* print true or false */
 std::cout << boost::apply_visitor(eq_pong, result_markers.result) << "\n";
-/* consume the buffers, after finish work with markers */
+/* consume the buffers, after finishing work with the markers */
 rx_buff.consume(result_markers.consumed);
 ```
 
-For *extraction* of results it is possible to use either shipped extactors or write custom one. Shipped extractors detach (copy / convert) extraction results from receive buffer.
+For *extraction* of results it is possible to use either one of the shipped extractors or to write a custom one. Shipped extractors detach (copy / convert) the extraction results from the receive buffer.
 
 ```cpp
 #include "bredis/Extract.hpp"
@@ -103,13 +103,13 @@ auto &reply_str = boost::get<r::extracts::string_t>(extract);
 std::cout << reply_str.str << "\n";
 ```
 
-Custom extractors (visitors) might be useful for performance-aware cases, e.g. when JSON in re-constructed in-place from using string reply markers **without** re-allocating whole JSON-string reply.
+Custom extractors (visitors) might be useful for performance-sensitive cases, e.g. when JSON is re-constructed in-place by using string reply markers **without** re-allocating the whole JSON-string reply.
 
-The underlying reason for decision to have final results in two steps (get markers and then scan/extract results) is caused by the fact that *receive buffer* might be scattered (fragmented). Scan and extraction can be performed without gathering receive buffers (i.e. without flattening / linearizing it).
+The underlying reason for the decision to retrieve the final results in two steps (get markers and then scan/extract results) is that the *receive buffer* might be scattered (fragmented). In such cases scan and extraction can be performed without gathering receive buffers (i.e. without flattening / linearizing it) if they are separate steps.
 
-In other words, *markers* have **referense semantics** (they refer memory regions in buffer, but do not own), while *extracted results* have **value semantics** (ownership).
+In other words, *markers* have **reference semantics** (they refer to memory regions in the buffer, but do not own it), while *extracted results* have **value semantics** (they take ownership).
 
-## Syncronous TCP-connection example
+## Synchronous TCP-connection example
 
 ```cpp
 #include "bredis/Connection.hpp"
@@ -141,17 +141,17 @@ c.write("ping");
 Buffer rx_buff;
 /* get the result markers */
 auto result_markers = c.read(rx_buff);
-/* check for the responce */
+/* check for the response */
 auto eq_pong = r::marker_helpers::equality<Iterator>("PONG");
 /* print true */
 std::cout << boost::apply_visitor(eq_pong, result_markers.result) << "\n";
-/* consume the buffers, after finish work with markers */
+/* consume the buffers, after finishing work with the markers */
 rx_buff.consume(result_markers.consumed);
 ```
 
-In the ping example above the `PONG` reply string from redis is not (re)allocated, but directly scanned in the `rx_buff` using result markers. This can be useful for performance-aware cases, e.g. when JSON in re-constructed in-place from using string reply markers **without** re-allocating whole JSON-string reply.
+In the ping example above the `PONG` reply string from redis is not (re)allocated, but directly scanned from the `rx_buff` using a result markers. This can be useful for performance-sensitive cases, e.g. when JSON is re-constructed in-place by using string reply markers **without** re-allocating the whole JSON-string reply.
 
-In the case of need to **extract** reply (i.e. detach it from `rx_buff`), the following can be done:
+In cases where you need to **extract** the reply (i.e. to detach it from `rx_buff`), the following can be done:
 
 ```cpp
 #include "bredis/Extract.hpp"
@@ -167,7 +167,7 @@ auto &reply_str = boost::get<r::extracts::string_t>(extract);
 std::cout << reply_str.str << "\n";
 ```
 
-The examples above throw Exception in case of I/O or protocol error. It can be used as:
+The examples above throw an exception in case of I/O or protocol errors. Another way to use the API is
 
 ```cpp
 boost::system::error_code ec;
@@ -176,9 +176,9 @@ c.write("ping", ec);
 parse_result = c.read(rx_buff, ec);
 ```
 
-in the case you don't want to the throw-exception behaviour
+in case you don't want the throw-exception behaviour.
 
-## Asyncronous TCP-connection example
+## Asynchronous TCP-connection example
 ```cpp
 #include "bredis/Connection.hpp"
 #include "bredis/MarkerHelpers.hpp"
@@ -193,7 +193,7 @@ using Policy = r::parsing_policy::keep_result;
 using result_t = r::parse_result_mapper_t<Iterator, Policy>;
 
 ...
-/* establishing connection to redis is outside of bredis */
+/* establishing the connection to redis is outside of bredis */
 asio::ip::tcp::endpoint end_point(
     asio::ip::address::from_string("127.0.0.1"), port);
 socket_t socket(io_service, end_point.protocol());
@@ -205,7 +205,7 @@ c.async_write(
         /* tx_buff must be consumed when it is no longer needed */
         tx_buff.consume(bytes_transferred);
         c.async_read(rx_buff, [&](const auto &error_code, result_t &&r) {
-            /* see above how to work wit result */
+            /* see above how to work with the result */
             auto extract = boost::apply_visitor(r::extractor<Iterator>(), r.result);
             auto &queue_size = boost::get<r::extracts::int_t>(extract);
             std::cout << "queue size: " << queue_size << "\n";
@@ -217,12 +217,12 @@ c.async_write(
 
 ```
 
-In the example above separete receive and transfer buffers are used. In theory you can use only one buffer for both operations, but you must ensure that it will not be used simultaneously for reading and writing, in other words you cannot use [pipelining](https://redis.io/topics/pipelining) redis feature.
+In the example above separate receive and transfer buffers are used. In theory you can use only one buffer for both operations, but you must ensure that it will not be used simultaneously for reading and writing, in other words you cannot use the [pipelining](https://redis.io/topics/pipelining) redis feature.
 
 
-## Asyncronous unix domain sockets connection
+## Asynchronous unix domain socket connections
 
-The same as above, except the underlying socket type should be changed:
+The same as above, except the underlying socket type must be changed:
 
 ```cpp
 using socket_t = asio::local::stream_protocol::socket;
@@ -230,7 +230,7 @@ using socket_t = asio::local::stream_protocol::socket;
 
 ## Subscriptions
 
-There is no specific support of subscriptions, but you can easily build your own like
+There is no specific support for subscriptions, but you can easily build your own like
 
 ### synchronous subscription
 
@@ -267,18 +267,18 @@ while(true) {
 }
 ```
 
-See `examples/synch-subscription.cpp` for the full example
+See `examples/synch-subscription.cpp` for the full example.
 
 ### asynchronous subscription
 
-The similar way of synchronous, i.e. push read callback initially and after each successfull read
+These work similarly to the synchronous approach. However you have to provide a read callback initially and again after each successfull read
 ```cpp
 using Policy = r::parsing_policy::keep_result;
 using ParseResult = r::parse_result_mapper_t<Iterator, Policy>;
 using read_callback_t = std::function<void(const boost::system::error_code &error_code, ParseResult &&r)>;
 using Extractor = r::extractor<Iterator>;
 ...
-/* we can execute subscription command synchronously, as it is easier */
+/* we can execute the subscription command synchronously, as it is easier */
 c.command("subscribe", "channel-1", "channel-2");
 ...
 Buffer rx_buff;
@@ -296,13 +296,13 @@ read_callback_t notification_callback = [&](const boost::system::error_code,
 c.async_read(rx_buff, notification_callback);
 ```
 
-See `examples/stream-parse.cpp` for the full example
+See `examples/stream-parse.cpp` for the full example.
 
 ## Transactions
 
-There is no specific support for transactions in bredis, but you can easily build your own for you needs.
+There is no specific support for transactions in bredis, but you can easily build your own for your needs.
 
-First, wrap your commands into tranaction:
+First, wrap your commands into a transaction:
 
 ```cpp
 
@@ -316,9 +316,9 @@ r::command_wrapper_t cmd(tx_commands);
 c.write(cmd);
 ```
 
-Then, as above there was **4** redis commands, there should come **4** redis
-replies: `OK`, `QUEUED`, `QUEUED` and the array of results of execution of commands
-in transaction (i.e. results for `INCR` and `GET` above)
+Then, as above there were **4** redis commands, there we should receive **4** redis
+replies: `OK`, `QUEUED`, `QUEUED` followed by the array of results of the execution of the commands
+in the transaction (i.e. results for `INCR` and `GET` above)
 
 ```cpp
 Buffer rx_buff;
@@ -344,7 +344,7 @@ c.async_read(rx_buff, [&](const auto& error_code, auto&& r){
 
 ## Futures & Coroutines
 
-The similiar way as in `Boost::ASIO` (special thanks to Vinnie Falko for the suggestion)
+Done in a similiar way as in `Boost::ASIO` (special thanks to Vinnie Falko for the suggestion)
 
 ### Futures
 
@@ -380,17 +380,17 @@ boost::asio::spawn(
 
 ## Inspecting network traffic
 
-See `t/SocketWithLogging.hpp` for example. The main idea is quite simple:
-instead of providing real socket implementation supplied by `Boost::ASIO`,
-provide an wrapper (proxy) which will **spy** on the traffic before
-delegating it to/from `Boost::ASIO` socket.
+See `t/SocketWithLogging.hpp` for an example. The main idea is quite simple:
+Instead of providing a real socket implementation supplied by `Boost::ASIO`,
+provide a wrapper (proxy) which will **spy** on the traffic before
+delegating it to/from a `Boost::ASIO` socket.
 
 ## Cancellation & other socket operations
 
-There is nothing specific with bredis, but if you need low-level socket
+There is nothing specific to this in bredis. If you need low-level socket
 operations, instead of moving *socket* into bredis connection, you can
-simply move a *reference* to it, and keep (own) the socket somewhere
-outside of bredis connection.
+simply move a *reference* to it and keep (own) the socket somewhere
+outside of the bredis connection.
 
 ```cpp
 using socket_t = asio::ip::tcp::socket;
@@ -408,7 +408,7 @@ socket.cancel();
 
 ### `Iterator` template
 
-underlying iterator type for used dynamic buffer type (e.g. `boost::asio::streambuf`)
+The underlying iterator type used for the dynamic buffer type (e.g. `boost::asio::streambuf`)
 
 ### `redis_result_t<Iterator>`
 
@@ -417,7 +417,7 @@ Header: `include/bredis/Markers.hpp`
 Namespace: `bredis::markers`
 
 
-`boost::variant` for the basic types in redis protocol [](https://redis.io/topics/protocol),
+`boost::variant` for the basic types in the redis protocol [](https://redis.io/topics/protocol),
 i.e. the following marker types :
 - `nil_t<Iterator>`
 - `int_t<Iterator>`
@@ -425,15 +425,15 @@ i.e. the following marker types :
 - `error_t<Iterator>`
 - `array_holder_t<Iterator>`
 
-The basic type is `string_t<Iterator>`, which contains `from` and `to` members (`Iterator`),
-where string is held. String does not contain special redis-protocol symbols, and other
-metadata, i.e. can be used to extract/flatten the whole string.
+The basic type is `string_t<Iterator>`, which contains `from` and `to` members (`Iterator`)
+to where the string is held. String does not contain the special redis-protocol symbols or any other
+metadata, i.e. it can be used to extract/flatten the whole string.
 
-`nil_t<Iterator>`, `int_t<Iterator>`, `error_t<Iterator>` just have `string` member
-to point underlying string in redis protocol.
+`nil_t<Iterator>`, `int_t<Iterator>`, `error_t<Iterator>` just have a `string` member
+to point to the underlying string in the redis protocol.
 
-`array_holder_t` is recursive wrapper for the `redis_result_t<Iterator>`, it contains
-`elements` member of `std::array` of `redis_result_t<Iterator>`
+`array_holder_t` is recursive wrapper for the `redis_result_t<Iterator>`, it contains a
+`elements` member of `std::array` of `redis_result_t<Iterator>` type.
 
 ### `parse_result_t<Iterator, Policy>`
 
@@ -441,32 +441,32 @@ Header: `include/bredis/Result.hpp`
 
 Namespace: `bredis`
 
-Represents results of parse attempt. It is `boost::variant` of the following types:
+Represents the results of a parse attempt. It is a `boost::variant` of the following types:
 - `no_enogh_data_t`
 - `protocol_error_t`
 - `positive_parse_result_t<Iterator, Policy>`
 
-`no_enogh_data_t` is empty struct, meaning that buffer just does not contains enough
+`no_enogh_data_t` is a empty struct. It means that buffer just does not contain enough
 information to completely parse it.
 
-`protocol_error_t` has `boost::system::error_code code` member, descriping the error
-in protocol, (e.g. when type in stream is specified as integer, but it cannot be
-converted to integer). This error should never occur in production code, meaning
-that no (logical) errors are expected in redis-server nor in bredis parser. The
-error might occur if buffer is corrupted.
+`protocol_error_t` has a `boost::system::error_code code` member. It describes the error
+in the protocol (e.g. when the type in the stream is specified as an integer, but it cannot be
+converted to an integer). This error should never occur in production code, meaning
+that no (logical) errors are expected in the redis-server nor in the bredis parser. The
+error might occur if the buffer is corrupted.
 
-`Policy` (namespace `bredis::parsing_policy`) specifies what to do with with result:
-either drop it (`bredis::parsing_policy::drop_result`) or keep it
+`Policy` (namespace `bredis::parsing_policy`) specifies what to do with the result:
+Either drop it (`bredis::parsing_policy::drop_result`) or keep it
 (`bredis::parsing_policy::keep_result`). The helper
-`parse_result_mapper_t<Iterator, Policy>` helps to get proper
+`parse_result_mapper_t<Iterator, Policy>` helps to get the proper
 `positive_parse_result_t<Iterator, Policy>` type.
 
 `positive_parse_result_t<Iterator, Policy>` contains members:
-- `markers::redis_result_t<Iterator> result` - result of mark-up buffer; can be used
+- `markers::redis_result_t<Iterator> result` - the result of mark-up buffer; can be used
 either for scanning for particular results or for extraction of results. Valid only
 for `keep_result` policy.
-- `size_t consumed` - how many bytes of receive buffer must be consumed, after
-using `result` field.
+- `size_t consumed` - how many bytes of receive buffer must be consumed after
+using the `result` field.
 
 ### marker helpers
 
@@ -476,22 +476,22 @@ Namespace: `bredis::marker_helpers`
 
 #### `stringizer<Iterator>`
 
-Apply this `boost::static_visitor<std::string>`s for
+Apply this `boost::static_visitor<std::string>`s to
 stringize the result (can be useful for debugging).
 
 #### `equality<Iterator>`
 
-Apply this `boost::static_visitor<bool>` to find *string* in the
+Apply this `boost::static_visitor<bool>` to find a *string* in the
 parsed results (the markup can point to integer types, but as it
-is transferred as string anyway, it still can be founded as string
-too)
+is transferred as a string anyway, it still can be founded as string
+too).
 
 Constructor: `equality<Iterator>(std::string str)`
 
 #### `check_subscription<Iterator>`
 
-This `boost::static_visitor<bool>` hepler is used to check
-whether redis reply confirms to one of requested channels. Hence,
+This `boost::static_visitor<bool>` helper is used to check
+whether the redis reply confirms one of the requested channels. Hence,
 the constructor is `check_subscription(single_command_t)`.
 
 Usually, the redis subscription reply is in the form:
@@ -503,16 +503,16 @@ Usually, the redis subscription reply is in the form:
 }
 ```
 
-So, it checks, that:
-1. Redis reply is 3-element array
-2. The 1st reply element is string, and it *case-insentensively*
-matches the command, i.e.  is is supposed, that
-command will be `subscribe` or `psubscribe`.
-3. That 3rd reply element is reference, and it is presented
-among command arguments.
+So it checks that:
+1. The redis reply is a 3-element array
+2. The 1st reply element is a string, and it *case-insensitively*
+matches the command, i.e. it is assumed, that
+command will be `subscribe` or `psubscribe` depending on the original command
+3. That the 3rd reply element is a reference, and it is present
+among the command arguments.
 
 It is possible to reuse the same `check_subscription<Iterator>`
-to *multiple* redis replies to signle subsription command.
+on *multiple* redis replies to a single subsription command for multiple channels.
 
 Example:
 
@@ -521,8 +521,8 @@ bredis::single_command_t subscribe_cmd{
     "subscribe", "channel-1", "channel-2"
 };
 ...
-// write command, so the subscribe_cmd
-// will be no longer required
+// write the command, so the subscribe_cmd
+// will be no longer be required
 ...;
 bredis::marker_helpers::check_subscription<Iterator>
     check_subscription{std::move(subscribe_cmd)};
@@ -546,7 +546,7 @@ Namespace: `bredis`
 - `single_command_t`
 - `command_container_t`
 
-`single_command_t` represents single redis command with all it's arguments, e.g.:
+`single_command_t` represents a single redis command with all its arguments, e.g.:
 
 ```cpp
 // compile-time version
@@ -563,8 +563,8 @@ r::single_command_t cmd_subscribe {
 
 The arguments must be conversible to `boost::string_ref`.
 
-`command_container_t` is `std::vector` of `single_command_t`. Useful for transactions
-or buck messages creation.
+`command_container_t` is a `std::vector` of `single_command_t`. It is useful for transactions
+or bulk message creation.
 
 ### `Connection<NextLayer>`
 
@@ -572,43 +572,43 @@ Header: `include/bredis/Connection.hpp`
 
 Namespace: `bredis`
 
-A thin wrapper around `NextLayer`; represents connection to redis. `NextLayer` can
-be either `asio::ip::tcp::socket` or `asio::ip::tcp::socket&` or custom wrapper, which
+A thin wrapper around `NextLayer`; represents a connection to redis. `NextLayer` can
+be either `asio::ip::tcp::socket` or `asio::ip::tcp::socket&` or a custom wrapper, which
 follows the specification of `asio::ip::tcp::socket`.
 
-Constructor `template <typename... Args> Connection(Args &&... args)` used for
+The constructor `template <typename... Args> Connection(Args &&... args)` is used for the
 construction of NextLayer (stream interface).
 
 Stream interface accessors:
 - `NextLayer &next_layer()`
 - `const NextLayer &next_layer() const`
 
-return underlying stream object.
+return the underlying stream object.
 
 #### Synchronous interface
 
-Perform synchonous write of redis command:
+Performs a synchonous write of a redis command:
 
 - `void write(const command_wrapper_t &command)`
 - `void write(const command_wrapper_t &command, boost::system::error_code &ec)`
 
-Perform synchonous read of redis result until the buffer will be parsed or
-some error (procol or I/O) occurs:
+Performs a synchronous read of a redis result until the buffer is parsed or
+some error (protocol or I/O) occurs:
 
 - `template <typename DynamicBuffer> positive_parse_result_t<Iterator, Policy = bredis::parsing_policy::keep_result> read(DynamicBuffer &rx_buff)`
 - `template <typename DynamicBuffer> positive_parse_result_t<Iterator, Policy = bredis::parsing_policy::keep_result> read(DynamicBuffer &rx_buff, boost::system::error_code &ec);`
 
-`DynamicBuffer` must conform `boost::asio::streambuf` interface.
+`DynamicBuffer` must conform to the `boost::asio::streambuf` interface.
 
 #### Asynchronous interface
 
 ##### async_write
 
-`WriteCallback` template should be callable object with the signature:
+The `WriteCallback` template should be a callable object with the signature:
 
 `void (const boost::system::error_code&, std::size_t bytes_transferred)`
 
-The asynchnous write has the following signature:
+The asynchronous write has the following signature:
 
 ```cpp
 void-or-deduced
@@ -616,21 +616,21 @@ async_write(DynamicBuffer &tx_buff, const command_wrapper_t &command,
                 WriteCallback write_callback)
 ```
 
-It write the redis command (or commands) into *transfer buffer*, sends them
-to the *next_layer* stream, and invokes `write_callback` after completion.
+It writes the redis command (or commands) into a *transfer buffer*, sends them
+to the *next_layer* stream and invokes `write_callback` after completion.
 
 `tx_buff` must consume `bytes_transferred` upon `write_callback` invocation.
 
-Client must guarantee that `async_write` is not invoked, until the previous
+The client must guarantee that `async_write` is not invoked until the previous
 invocation is finished.
 
 ##### async_read
 
-`ReadCallback` template should be callable object with the signature:
+`ReadCallback` template should be a callable object with the signature:
 
 `void(boost::system::error_code, r::positive_parse_result_t<Iterator, Policy = bredis::parsing_policy::keep_result>&& result)`
 
-The asynchnous read has the following signature:
+The asynchronous read has the following signature:
 
 ```cpp
 void-or-deduced
@@ -638,18 +638,18 @@ async_read(DynamicBuffer &rx_buff, ReadCallback read_callback,
                std::size_t replies_count = 1);
 ```
 
-It reads `replies_count` replies from the *nex_layer* steam, which will be
-stored in `rx_buff`, or until error (I/O or procol) will be met; then
+It reads `replies_count` replies from the *next_layer* stream, which will be
+stored in `rx_buff`, or until an error (I/O or protocol) is encountered; then
 `read_callback` will be invoked.
 
-If `replies_count` is greater then `1`, the result type will always be
+If `replies_count` is greater than `1`, the result type will always be
 `bredis::array_wrapper_t`; if the `replies_count` is `1` then the result type
 depends on redis answer type.
 
-On `read_callback` invocation with successfull parse result it is expected,
-that `rx_buff` will consume the specified in `result` amount of bytes.
+On `read_callback` invocation with a successful parse result it is expected,
+that `rx_buff` will consume the amount of bytes specified in the `result`.
 
-Client must guarantee that `async_read` is not invoked, until the previous
+The client must guarantee that `async_read` is not invoked until the previous
 invocation is finished. If you invoke `async_read` from `read_callback`
 don't forget to **consume** `rx_buff` first, otherwise it leads to
 subtle bugs.

--- a/README.md
+++ b/README.md
@@ -442,11 +442,11 @@ Header: `include/bredis/Result.hpp`
 Namespace: `bredis`
 
 Represents the results of a parse attempt. It is a `boost::variant` of the following types:
-- `no_enogh_data_t`
+- `not_enough_data_t`
 - `protocol_error_t`
 - `positive_parse_result_t<Iterator, Policy>`
 
-`no_enogh_data_t` is a empty struct. It means that buffer just does not contain enough
+`not_enough_data_t` is a empty struct. It means that buffer just does not contain enough
 information to completely parse it.
 
 `protocol_error_t` has a `boost::system::error_code code` member. It describes the error

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ parsing libraries (written from scratch vs [hiredis](https://github.com/redis/hi
 
 The general idea is that the result of trying to parse a redis reply can be either: not enough data, protocol error (in an extreme case) or some positive parse result. The last one is just **markers** of the result, which is actually stored in the *receive buffer* (i.e. outside of markers, and outside of the bredis-connection).
 
-The the further work with markers depends on your needs: it is possible to either **scan** the result for the expected results (e.g. for a `PONG` reply on a `PING` command, or for `OK`/`QUEUED` replies on `MULTI`/`EXEC` commands) or to **extract** the results (the common redis types: `nil`, `string`, `error`, `int` or a (recursive) array of them).
+The further work with markers depends on your needs: it is possible to either **scan** the result for the expected results (e.g. for a `PONG` reply on a `PING` command, or for `OK`/`QUEUED` replies on `MULTI`/`EXEC` commands) or to **extract** the results (the common redis types: `nil`, `string`, `error`, `int` or a (recursive) array of them).
 
 When the data in the receive buffer is no longer required, it should be consumed.
 


### PR DESCRIPTION
I'm currently looking at cpp-bredis and noticed various typos, missing articles and other minor issues w.r.t to the English grammar in the readme that made it a bit hard to read.

I tried to correct as many of them as I could find without changing the meaning or touching too much. I didn't try to do many changes to punctuation. English isn't my first language so I'm never 100% sure when to place them though I'm pretty sure one could remove a lot of the ","s.
