### PR TITLE
Fixed level 4 warning in MSVC

### DIFF
--- a/include/bredis/Markers.hpp
+++ b/include/bredis/Markers.hpp
@@ -8,6 +8,7 @@
 
 #include <boost/variant.hpp>
 #include <boost/variant/recursive_variant.hpp>
+#include <vector>
 
 namespace bredis {
 

--- a/include/bredis/impl/protocol.ipp
+++ b/include/bredis/impl/protocol.ipp
@@ -336,7 +336,7 @@ template <typename Iterator, typename Policy> struct array_parser_t {
 
         auto count = count_wrapped->value;
         array_helper elements{count_wrapped->consumed, count};
-        long marked_elements{0};
+        size_t marked_elements{0};
         Iterator element_from =
             from + (count_wrapped->consumed - already_consumed);
         while (marked_elements < count) {


### PR DESCRIPTION
Also added a header file so `Markers.hpp` can be included independently