### PR TITLE
Remove deprecated API usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ enable_testing()
 
 add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
 add_definitions(-DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
+add_definitions(-DBOOST_ASIO_NO_DEPRECATED)
 #add_definitions(-DBREDIS_DEBUG)
 
 find_package(

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ using Iterator = typename r::to_iterator<Buffer>::iterator_t;
 ...
 /* establishing connection to redis is outside of bredis */
 asio::ip::tcp::endpoint end_point(
-    asio::ip::address::from_string("127.0.0.1"), port);
+    asio::ip::make_address("127.0.0.1"), port);
 socket_t socket(io_service, end_point.protocol());
 socket.connect(end_point);
 
@@ -234,7 +234,7 @@ using result_t = r::parse_result_mapper_t<Iterator, Policy>;
 ...
 /* establishing the connection to redis is outside of bredis */
 asio::ip::tcp::endpoint end_point(
-    asio::ip::address::from_string("127.0.0.1"), port);
+    asio::ip::make_address("127.0.0.1"), port);
 socket_t socket(io_service, end_point.protocol());
 socket.connect(end_point);
 ...
@@ -467,7 +467,7 @@ outside of the bredis connection.
 using socket_t = asio::ip::tcp::socket;
 using next_layer_t = socket_t &;
 ...
-asio::ip::tcp::endpoint end_point(asio::ip::address::from_string("127.0.0.1"), port);
+asio::ip::tcp::endpoint end_point(asio::ip::make_address("127.0.0.1"), port);
 socket_t socket(io_service, end_point.protocol());
 socket.connect(end_point);
 r::Connection<next_layer_t> c(socket);

--- a/examples/multi-threads-1.cpp
+++ b/examples/multi-threads-1.cpp
@@ -138,8 +138,8 @@ int main(int argc, char **argv) {
     uint16_t port = vm.count("host") ? vm["port"].as<std::uint16_t>() : 6379;
 
     asio::io_context io;
-    //asio::io_service io_service;
-    auto ip_address = asio::ip::address::from_string(host);
+    //asio::io_context io_service;
+    auto ip_address = asio::ip::make_address(host);
     std::cout << "connecting to " << host << ":" << port << "\n";
     asio::ip::tcp::endpoint end_point(ip_address, port);
     socket_t socket(io, end_point.protocol());

--- a/examples/speed_test_async_multi.cpp
+++ b/examples/speed_test_async_multi.cpp
@@ -91,8 +91,8 @@ int main(int argc, char **argv) {
 
     r::command_wrapper_t cmd_wpapper{std::move(cmd_container)};
 
-    asio::io_service io_service;
-    auto ip_address = asio::ip::address::from_string(dst_parts[0]);
+    asio::io_context io_service;
+    auto ip_address = asio::ip::make_address(dst_parts[0]);
     auto port = boost::lexical_cast<std::uint16_t>(dst_parts[1]);
     std::cout << "connecting to " << address << "\n";
     asio::ip::tcp::endpoint end_point(ip_address, port);

--- a/examples/stream-parse.cpp
+++ b/examples/stream-parse.cpp
@@ -113,8 +113,8 @@ int main(int argc, char **argv) {
     std::copy(&argv[2], &argv[argc], std::back_inserter(cmd_items));
 
     // connect to redis
-    asio::io_service io_service;
-    auto ip_address = asio::ip::address::from_string(dst_parts[0]);
+    asio::io_context io_service;
+    auto ip_address = asio::ip::make_address(dst_parts[0]);
     auto port = boost::lexical_cast<std::uint16_t>(dst_parts[1]);
     std::cout << "connecting to " << address << "\n";
     asio::ip::tcp::endpoint end_point(ip_address, port);

--- a/examples/synch-subscription.cpp
+++ b/examples/synch-subscription.cpp
@@ -111,8 +111,8 @@ int main(int argc, char **argv) {
 
     try {
         // connect to redis
-        asio::io_service io_service;
-        auto ip_address = asio::ip::address::from_string(dst_parts[0]);
+        asio::io_context io_service;
+        auto ip_address = asio::ip::make_address(dst_parts[0]);
         auto port = boost::lexical_cast<std::uint16_t>(dst_parts[1]);
         std::cout << "connecting to " << address << "\n";
         asio::ip::tcp::endpoint end_point(ip_address, port);

--- a/include/bredis/impl/async_op.ipp
+++ b/include/bredis/impl/async_op.ipp
@@ -176,21 +176,14 @@ class async_read_op {
         return asio_handler_is_continuation(std::addressof(op->callback_));
     }
 
-    friend void *asio_handler_allocate(std::size_t size, async_read_op *op) {
-        using boost::asio::asio_handler_allocate;
-        return asio_handler_allocate(size, std::addressof(op->callback_));
+    boost::asio::associated_allocator_t<ReadCallback> get_allocator() const noexcept
+    {
+        return boost::asio::get_associated_allocator(callback_);
     }
 
-    friend void asio_handler_deallocate(void *p, std::size_t size,
-                                        async_read_op *op) {
-        using boost::asio::asio_handler_deallocate;
-        return asio_handler_deallocate(p, size, std::addressof(op->callback_));
-    }
-
-    template <class Function>
-    friend void asio_handler_invoke(Function &&f, async_read_op *op) {
-        using boost::asio::asio_handler_invoke;
-        return asio_handler_invoke(f, std::addressof(op->callback_));
+    boost::asio::associated_executor_t<ReadCallback> get_executor() const noexcept
+    {
+        return boost::asio::get_associated_executor(callback_);
     }
 };
 

--- a/t/05-protocol.cpp
+++ b/t/05-protocol.cpp
@@ -9,7 +9,7 @@
 namespace r = bredis;
 namespace asio = boost::asio;
 
-using Buffer = asio::const_buffers_1;
+using Buffer = asio::const_buffer;
 using Iterator = boost::asio::buffers_iterator<Buffer, char>;
 using Policy = r::parsing_policy::keep_result;
 using positive_result_t = r::parse_result_mapper_t<Iterator, Policy>;

--- a/t/06-fragmented-buffer.cpp
+++ b/t/06-fragmented-buffer.cpp
@@ -12,7 +12,7 @@ namespace r = bredis;
 namespace asio = boost::asio;
 
 TEST_CASE("right consumption", "[protocol]") {
-    using Buffer = std::vector<asio::const_buffers_1>;
+    using Buffer = std::vector<asio::const_buffer>;
     using Iterator = boost::asio::buffers_iterator<Buffer, char>;
     using Policy = r::parsing_policy::keep_result;
     using positive_result_t = r::parse_result_mapper_t<Iterator, Policy>;
@@ -22,7 +22,7 @@ TEST_CASE("right consumption", "[protocol]") {
 
     Buffer buff;
     for (size_t i = 0; i < full_message.size(); i++) {
-        asio::const_buffers_1 v(full_message.c_str() + i, 1);
+        asio::const_buffer v(full_message.c_str() + i, 1);
         buff.push_back(v);
     }
     auto b_from = Iterator::begin(buff), b_to = Iterator::end(buff);

--- a/t/07-extract.cpp
+++ b/t/07-extract.cpp
@@ -8,7 +8,7 @@
 namespace r = bredis;
 namespace asio = boost::asio;
 
-using Buffer = asio::const_buffers_1;
+using Buffer = asio::const_buffer;
 using Iterator = boost::asio::buffers_iterator<Buffer, char>;
 
 TEST_CASE("string extraction", "[protocol]") {

--- a/t/10-ping.cpp
+++ b/t/10-ping.cpp
@@ -35,10 +35,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/11-multi-ping.cpp
+++ b/t/11-multi-ping.cpp
@@ -48,10 +48,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/12-basic-types.cpp
+++ b/t/12-basic-types.cpp
@@ -42,10 +42,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/13-protol-error.cpp
+++ b/t/13-protol-error.cpp
@@ -33,9 +33,9 @@ TEST_CASE("protocol-error", "[connection]") {
     std::chrono::milliseconds sleep_delay(1);
 
     uint16_t port = ep::get_random<ep::Kind::TCP>();
-    asio::io_service io_service;
+    asio::io_context io_service;
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     asio::ip::tcp::acceptor acceptor(io_service, end_point.protocol());
 
     acceptor.bind(end_point);
@@ -45,7 +45,7 @@ TEST_CASE("protocol-error", "[connection]") {
     std::string data = "bla-bla";
     std::string end_marker = "ping\r\n";
     Buffer remote_rx_buff;
-    asio::const_buffers_1 output_buf = asio::buffer(data.c_str(), data.size());
+    asio::const_buffer output_buf = asio::buffer(data.c_str(), data.size());
     acceptor.async_accept(peer_socket, [&](const sys::error_code &error_code) {
         (void)error_code;
         BREDIS_LOG_DEBUG("async_accept: " << error_code.message() << ", "

--- a/t/14-uds.cpp
+++ b/t/14-uds.cpp
@@ -65,7 +65,7 @@ TEST_CASE("ping", "[connection]") {
     }
     r::command_wrapper_t cmd(ping_cmds_container);
 
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::local::stream_protocol::endpoint end_point(redis_socket);
     socket_t socket(io_service, end_point.protocol());

--- a/t/15-cancellation.cpp
+++ b/t/15-cancellation.cpp
@@ -35,9 +35,9 @@ TEST_CASE("cancel-on-read", "[cancellation]") {
     std::chrono::milliseconds sleep_delay(1);
 
     uint16_t port = ep::get_random<ep::Kind::TCP>();
-    asio::io_service io_service;
+    asio::io_context io_service;
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     asio::ip::tcp::acceptor acceptor(io_service, end_point.protocol());
 
     acceptor.bind(end_point);

--- a/t/16-close-connection.cpp
+++ b/t/16-close-connection.cpp
@@ -33,9 +33,9 @@ TEST_CASE("close-afrer-read", "[connection]") {
     std::chrono::milliseconds sleep_delay(1);
 
     uint16_t port = ep::get_random<ep::Kind::TCP>();
-    asio::io_service io_service;
+    asio::io_context io_service;
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     asio::ip::tcp::acceptor acceptor(io_service, end_point.protocol());
 
     acceptor.bind(end_point);
@@ -105,9 +105,9 @@ TEST_CASE("close-before-write", "[connection]") {
     std::chrono::milliseconds sleep_delay(1);
 
     uint16_t port = ep::get_random<ep::Kind::TCP>();
-    asio::io_service io_service;
+    asio::io_context io_service;
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     asio::ip::tcp::acceptor acceptor(io_service, end_point.protocol());
 
     acceptor.bind(end_point);

--- a/t/17-sync.cpp
+++ b/t/17-sync.cpp
@@ -31,10 +31,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/18-subscription.cpp
+++ b/t/18-subscription.cpp
@@ -41,10 +41,10 @@ TEST_CASE("subscription", "[connection]") {
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
     // uint16_t port = 6379;
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/19-transaction.cpp
+++ b/t/19-transaction.cpp
@@ -40,7 +40,7 @@ TEST_CASE("transaction", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     r::command_container_t tx_commands = {
         r::single_command_t("MULTI"),
@@ -54,7 +54,7 @@ TEST_CASE("transaction", "[connection]") {
     std::future<result_t> completion_future = completion_promise.get_future();
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
     r::Connection<next_layer_t> c(std::move(socket));

--- a/t/20-promise.cpp
+++ b/t/20-promise.cpp
@@ -33,10 +33,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/21-coroutine.cpp
+++ b/t/21-coroutine.cpp
@@ -33,10 +33,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/22-ping_drop-policy.cpp
+++ b/t/22-ping_drop-policy.cpp
@@ -50,10 +50,10 @@ TEST_CASE("ping/drop-policy", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/23-stream.cpp
+++ b/t/23-stream.cpp
@@ -35,10 +35,10 @@ TEST_CASE("stream", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/24-dynbuff.cpp
+++ b/t/24-dynbuff.cpp
@@ -52,10 +52,10 @@ TEST_CASE("ping", "[connection]") {
     auto port_str = boost::lexical_cast<std::string>(port);
     auto server = ts::make_server({"redis-server", "--port", port_str});
     ep::wait_port<ep::Kind::TCP>(port);
-    asio::io_service io_service;
+    asio::io_context io_service;
 
     asio::ip::tcp::endpoint end_point(
-        asio::ip::address::from_string("127.0.0.1"), port);
+        asio::ip::make_address("127.0.0.1"), port);
     socket_t socket(io_service, end_point.protocol());
     socket.connect(end_point);
 

--- a/t/SocketWithLogging.hpp
+++ b/t/SocketWithLogging.hpp
@@ -45,14 +45,10 @@ class SocketWithLogging {
     template <typename BufferSequence>
     static void dump(const char *prefix, const BufferSequence &buffers,
                      std::size_t size) {
-        using boost::asio::buffer_cast;
-        using boost::asio::buffer_size;
-
         std::string content;
         content.reserve(size);
         for (auto const &buffer : buffers) {
-            content.append(buffer_cast<char const *>(buffer),
-                           buffer_size(buffer));
+            content.append(buffer.data(), buffer.size());
         }
         LogPolicy::log(prefix, content);
     }


### PR DESCRIPTION
Add BOOST_ASIO_NO_DEPRECATED for the build and fix the usages that breaks. #44 